### PR TITLE
Test team name on URL and fix it if necessary 

### DIFF
--- a/client/faultybot.py
+++ b/client/faultybot.py
@@ -35,7 +35,7 @@ async def kickfaulty(ctx, *args):
     if len(args) != 2:
         await ctx.send("Der Command >kickfaulty benötigt 2 Argumente: 1. Teamname; 2. OAuth Token")
         return False
-    team = check_team_name(args[0].lower())
+    team = function.check_team_name(args[0].lower())
     lichess_token = args[1]
     file_id = str(uuid.uuid4().hex)
     new = True
@@ -49,7 +49,7 @@ async def kickfaulty(ctx, *args):
 @bot.command()
 async def faulty(ctx, *args):
     new = False
-    team = check_team_name(args[0].lower())
+    team = function.check_team_name(args[0].lower())
     if len(args) > 1 and args[1] == "new":
         new = True
     file_id = str(uuid.uuid4().hex)
@@ -57,7 +57,7 @@ async def faulty(ctx, *args):
     # handle = [now, team, file_id, status]
     if id_ref[handle][3] == 1:  # team neu
         text = "Die Daten des Teams **" + args[0] + "** werden heruntergeladen und überprüft! Dies kann je nach " \
-                "Größe des Teams mehrere Minuten dauern. Pro 1000 Mitglieder ca. 1 Minute!"
+            "Größe des Teams mehrere Minuten dauern. Pro 1000 Mitglieder ca. 1 Minute!"
         await ctx.send(text)
         token = False
         await faultyhandle(ctx, team, args[0], handle, token)
@@ -78,6 +78,7 @@ async def faulty(ctx, *args):
                "** existiert offenbar nicht! \n- - - - - - - - - - - - - - - - - - - - - - - - - - - - "
         await ctx.send(text)
     return False
+
 
 async def kickal(ctx, team, arg, handle, token):
     try:
@@ -124,8 +125,10 @@ async def faultyhandle(ctx, team, arg, handle, token):
         count_cheater = 0
         for c in cheater:
             r = function.kick(team.lower(), c, token)
-            print("found " + str(len(cheater)) + " Cheater in Team " + str(team))
-            print("Request for Cheater " + str(count_cheater + 1) + " '" + c + "' returns " + str(r))
+            print("found " + str(len(cheater)) +
+                  " Cheater in Team " + str(team))
+            print("Request for Cheater " + str(count_cheater + 1) +
+                  " '" + c + "' returns " + str(r))
             if not function.check(r):
                 status = function.status(r)
                 text = "Der Kick Vorgang wurde aufgrund folgendem Fehler abgebrochen:\n" \

--- a/client/faultybot.py
+++ b/client/faultybot.py
@@ -35,7 +35,7 @@ async def kickfaulty(ctx, *args):
     if len(args) != 2:
         await ctx.send("Der Command >kickfaulty benötigt 2 Argumente: 1. Teamname; 2. OAuth Token")
         return False
-    team = args[0].lower()
+    team = check_team_name(args[0].lower())
     lichess_token = args[1]
     file_id = str(uuid.uuid4().hex)
     new = True
@@ -49,7 +49,7 @@ async def kickfaulty(ctx, *args):
 @bot.command()
 async def faulty(ctx, *args):
     new = False
-    team = args[0].lower()
+    team = check_team_name(args[0].lower())
     if len(args) > 1 and args[1] == "new":
         new = True
     file_id = str(uuid.uuid4().hex)

--- a/client/system/function.py
+++ b/client/system/function.py
@@ -3,7 +3,7 @@ import lichess.api
 import requests
 import time
 
-# check_user() : bool 
+# check_user() : bool
 def check_user(username):
     flag = False
     try:
@@ -17,7 +17,7 @@ def check_user(username):
 def check_user_ausgabe(username):
     if check_user(username):
         return "True"
-    else: 
+    else:
         return "False"
 
 
@@ -43,7 +43,7 @@ def kick(team, user, token):
     return r
 
 
-# Kick User  
+# Kick User
 def runner(team, token):
     for c in analyse_team(team.lower()):
         kick(team.lower(), c, token)
@@ -71,14 +71,16 @@ def status(level):
     return "No Error"
 
 # Clear Team
+
+
 def clear_team(team, token):
     try:
         for i in lichess.api.users_by_team(team):
-            username = i.get('username').lower()   
+            username = i.get('username').lower()
             url = 'https://lichess.org/team/'+team+'/kick/'+user
             header = {'Authorization': 'Bearer ' + token}
             r = requests.post(url, headers=header)
-            time.sleep(1) 
+            time.sleep(1)
     except:
         return False
     return True
@@ -89,9 +91,10 @@ def check_team_name(team):
     if "/team/" in team:
         x = len(team)
         while x > 0:
-            # Lichess cannot process teams with the "/" character for syntax reasons. 
-            # Therefore there are no such teams.  
+            # Lichess cannot process teams with the "/" character for syntax reasons.
+            # Therefore there are no such teams.
             if "/" in team[-x::]:
+                print(teamteam[-x::])
                 x = x - 1
             else:
                 return team[-x::]

--- a/client/system/function.py
+++ b/client/system/function.py
@@ -82,3 +82,21 @@ def clear_team(team, token):
     except:
         return False
     return True
+
+# If anyone operates the bot incorrectly, it will be checked again for errors here.
+def check_team_name(team):
+    # The program uses the static links from lichess
+    if "/team/" in team:
+        x = len(team)
+        while x > 0:
+            # Lichess cannot process teams with the "/" character for syntax reasons. 
+            # Therefore there are no such teams.  
+            if "/" in team[-x::]:
+                x = x - 1
+            else:
+                return team[-x::]
+                break
+    else:
+        return team
+    # The false can never be reached. It stands so that it looks better
+    return False


### PR DESCRIPTION
Extension for the Faultybot.
If a stupid user enters the complete team URL instead of the team name, it doesn't matter now. The function ``check_team_name`` now returns the requested element. 
However, the function can only handle one element and not a list.
The function is located in the function.py and is already integrated in the faultybot. 