### PR TITLE
Adding lichesspy to the package list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ urllib3>=1.26.4
 uuid>=1.30
 yarl>=1.6.3
 virtualenv>=20.4.6
+lichesspy>=0.1.8


### PR DESCRIPTION
We use lichesspy everywhere. However, we have never integrated it. That's why I'm making up for it here.